### PR TITLE
Fixed circular imports in init.py and autograd.py #5

### DIFF
--- a/python/needle/__init__.py
+++ b/python/needle/__init__.py
@@ -1,7 +1,7 @@
+from . import init
 from .autograd import Tensor, cpu, all_devices
 from . import ops
 from .ops import *
-from . import init
 from . import data
 from . import nn
 from . import optim

--- a/python/needle/autograd.py
+++ b/python/needle/autograd.py
@@ -1,9 +1,10 @@
 """Core data structures."""
 import needle
-from typing import List, Optional, NamedTuple, Tuple, Union
+from typing import List, Optional, NamedTuple, Tuple, Union, Dict
 from collections import namedtuple
 import numpy
-from needle import init
+
+from . import init
 
 # needle version
 LAZY_MODE = False

--- a/python/needle/init.py
+++ b/python/needle/init.py
@@ -1,27 +1,25 @@
-import math
-import needle as ndl
-
+from .autograd import Tensor, cpu
 
 
 def rand(*shape, low=0.0, high=1.0, device=None, dtype="float32", requires_grad=False):
     """ Generate random numbers uniform between low and high """
-    device = ndl.cpu() if device is None else device
+    device = cpu() if device is None else device
     array = device.rand(*shape) * (high - low) + low
-    return ndl.Tensor(array, device=device, dtype=dtype, requires_grad=requires_grad)
+    return Tensor(array, device=device, dtype=dtype, requires_grad=requires_grad)
     
 
 def randn(*shape, mean=0.0, std=1.0, device=None, dtype="float32", requires_grad=False):
     """ Generate random normal with specified mean and std deviation """
-    device = ndl.cpu() if device is None else device
+    device = cpu() if device is None else device
     array = device.randn(*shape) * std + mean
-    return ndl.Tensor(array, device=device, dtype=dtype, requires_grad=requires_grad)
+    return Tensor(array, device=device, dtype=dtype, requires_grad=requires_grad)
 
 
 def constant(*shape, c=1.0, device=None, dtype="float32", requires_grad=False):
     """ Generate constant Tensor """
-    device = ndl.cpu() if device is None else device
+    device = cpu() if device is None else device
     array = device.ones(*shape, dtype=dtype) * c # note: can change dtype
-    return ndl.Tensor(array, device=device, dtype=dtype, requires_grad=requires_grad)
+    return Tensor(array, device=device, dtype=dtype, requires_grad=requires_grad)
 
 
 def ones(*shape, device=None, dtype="float32", requires_grad=False):
@@ -36,15 +34,15 @@ def zeros(*shape, device=None, dtype="float32", requires_grad=False):
 
 def randb(*shape, p=0.5, device=None, dtype="bool", requires_grad=False):
     """ Generate binary random Tensor """
-    device = ndl.cpu() if device is None else device
+    device = cpu() if device is None else device
     array = device.rand(*shape) <= p
-    return ndl.Tensor(array, device=device, dtype=dtype, requires_grad=requires_grad)
+    return Tensor(array, device=device, dtype=dtype, requires_grad=requires_grad)
 
 
 def one_hot(n, i, device=None, dtype="float32", requires_grad=False):
     """ Generate one-hot encoding Tensor """
-    device = ndl.cpu() if device is None else device
-    return ndl.Tensor(device.one_hot(n,i.numpy(), dtype=dtype), device=device, requires_grad=requires_grad)
+    device = cpu() if device is None else device
+    return Tensor(device.one_hot(n,i.numpy(), dtype=dtype), device=device, requires_grad=requires_grad)
 
 
 def xavier_uniform(fan_in, fan_out, gain=1.0, **kwargs):


### PR DESCRIPTION
Fixed #5: Circular dependency between autograd.py and init.py.

Also changed "global" import in `autograd.py`:
`from needle import init` -> `from . import init`
