### PR TITLE
may be a typo

### DIFF
--- a/tests/test_nn_and_optim.py
+++ b/tests/test_nn_and_optim.py
@@ -541,7 +541,7 @@ def test_nn_linear_weight_init_1():
 def test_nn_linear_bias_init_1():
     np.testing.assert_allclose(nn_linear_bias_init(),
         np.array([[ 0.077647,  0.814139, -0.770975,  1.120297]],
-         dtype=np.float32), rtol=1e-5, atol=1e-5)
+         dtype=np.float32) * 2, rtol=1e-5, atol=1e-5)
 
 def test_nn_linear_forward_1():
     np.testing.assert_allclose(linear_forward((10, 5), (1, 10)),


### PR DESCRIPTION
## I can pass all "init" test:
```shell
(myenv) C:\Users\Administrator\Desktop\Deep-Learning-Systems-Algorithms-and-Implementation>pytest -v -k "test_init"
=========================================================== test session starts ===========================================================
platform win32 -- Python 3.9.15, pytest-7.2.1, pluggy-1.0.0 -- C:\Users\Administrator\anaconda3\envs\myenv\python.exe
cachedir: .pytest_cache
rootdir: C:\Users\Administrator\Desktop\Deep-Learning-Systems-Algorithms-and-Implementation
collected 112 items / 108 deselected / 4 selected                                                                                          

tests/test_nn_and_optim.py::test_init_kaiming_uniform PASSED                                                                         [ 25%]
tests/test_nn_and_optim.py::test_init_kaiming_normal PASSED                                                                          [ 50%]
tests/test_nn_and_optim.py::test_init_xavier_uniform PASSED                                                                          [ 75%]
tests/test_nn_and_optim.py::test_init_xavier_normal PASSED                                                                           [100%]

==================================================== 4 passed, 108 deselected in 0.56s ====================================================

```

## Before the modification, I failed  tests/test_nn_and_optim.py::test_nn_linear_bias_init_1
```shell
(myenv) C:\Users\Administrator\Desktop\Deep-Learning-Systems-Algorithms-and-Implementation>pytest -v -k "test_nn_linear"
=========================================================== test session starts ===========================================================
platform win32 -- Python 3.9.15, pytest-7.2.1, pluggy-1.0.0 -- C:\Users\Administrator\anaconda3\envs\myenv\python.exe
cachedir: .pytest_cache
rootdir: C:\Users\Administrator\Desktop\Deep-Learning-Systems-Algorithms-and-Implementation
collected 112 items / 104 deselected / 8 selected                                                                                          

tests/test_nn_and_optim.py::test_nn_linear_weight_init_1 PASSED                                                                      [ 12%]
tests/test_nn_and_optim.py::test_nn_linear_bias_init_1 FAILED                                                                        [ 25%]
tests/test_nn_and_optim.py::test_nn_linear_forward_1 PASSED                                                                          [ 37%]
tests/test_nn_and_optim.py::test_nn_linear_forward_2 PASSED                                                                          [ 50%]
tests/test_nn_and_optim.py::test_nn_linear_forward_3 PASSED                                                                          [ 62%]
tests/test_nn_and_optim.py::test_nn_linear_backward_1 PASSED                                                                         [ 75%]
tests/test_nn_and_optim.py::test_nn_linear_backward_2 PASSED                                                                         [ 87%]
tests/test_nn_and_optim.py::test_nn_linear_backward_3 PASSED                                                                         [100%]

================================================================ FAILURES =================================================================
_______________________________________________________ test_nn_linear_bias_init_1 ________________________________________________________

    def test_nn_linear_bias_init_1():
>       np.testing.assert_allclose(nn_linear_bias_init(),
            np.array([[ 0.077647,  0.814139, -0.770975,  1.120297]],
             dtype=np.float32), rtol=1e-5, atol=1e-5) # I add "multiply 2"
E       AssertionError: 
E       Not equal to tolerance rtol=1e-05, atol=1e-05
E       
E       Mismatched elements: 4 / 4 (100%)
E       Max absolute difference: 1.1202965
E       Max relative difference: 1.0000094
E        x: array([[ 0.155295,  1.628277, -1.541949,  2.240593]], dtype=float32)
E        y: array([[ 0.077647,  0.814139, -0.770975,  1.120297]], dtype=float32)

tests\test_nn_and_optim.py:542: AssertionError
========================================================= short test summary info =========================================================
FAILED tests/test_nn_and_optim.py::test_nn_linear_bias_init_1 - AssertionError:
=============================================== 1 failed, 7 passed, 104 deselected in 0.70s ===============================================

(myenv) C:\Users\Administrator\Desktop\Deep-Learning-Systems-Algorithms-and-Implementation>
```

## After the modification,  I pass all nn_linear tests
```console
(myenv) C:\Users\Administrator\Desktop\Deep-Learning-Systems-Algorithms-and-Implementation>pytest -v -k "test_nn_linear"
=========================================================== test session starts ===========================================================
platform win32 -- Python 3.9.15, pytest-7.2.1, pluggy-1.0.0 -- C:\Users\Administrator\anaconda3\envs\myenv\python.exe
cachedir: .pytest_cache
rootdir: C:\Users\Administrator\Desktop\Deep-Learning-Systems-Algorithms-and-Implementation
collected 112 items / 104 deselected / 8 selected                                                                                          

tests/test_nn_and_optim.py::test_nn_linear_weight_init_1 PASSED                                                                      [ 12%]
tests/test_nn_and_optim.py::test_nn_linear_bias_init_1 PASSED                                                                        [ 25%]
tests/test_nn_and_optim.py::test_nn_linear_forward_1 PASSED                                                                          [ 37%]
tests/test_nn_and_optim.py::test_nn_linear_forward_2 PASSED                                                                          [ 50%]
tests/test_nn_and_optim.py::test_nn_linear_forward_3 PASSED                                                                          [ 62%]
tests/test_nn_and_optim.py::test_nn_linear_backward_1 PASSED                                                                         [ 75%]
tests/test_nn_and_optim.py::test_nn_linear_backward_2 PASSED                                                                         [ 87%]
tests/test_nn_and_optim.py::test_nn_linear_backward_3 PASSED                                                                         [100%]

==================================================== 8 passed, 104 deselected in 0.65s ====================================================

```